### PR TITLE
completed read functionality of characters

### DIFF
--- a/components/CharacterCard.js
+++ b/components/CharacterCard.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import Button from 'react-bootstrap/Button';
+import Card from 'react-bootstrap/Card';
+import PropTypes from 'prop-types';
+
+function CharacterCard({ charObj }) {
+  return (
+    <Card style={{ width: '18rem' }}>
+      <Card.Img variant="top" src={charObj.image} style={{ height: '100px', width: '180px' }} />
+      <Card.Body>
+        <Card.Title>{charObj.name}</Card.Title>
+        <Card.Text>{charObj.role}</Card.Text>
+        <Button variant="success" href={`/character/edit/${charObj.firebaseKey}`} passHref>Edit</Button>
+        <Button variant="danger">Delete</Button>
+      </Card.Body>
+    </Card>
+  );
+}
+
+CharacterCard.propTypes = {
+  charObj: PropTypes.shape({
+    image: PropTypes.string,
+    name: PropTypes.string,
+    role: PropTypes.string,
+    firebaseKey: PropTypes.string,
+  }).isRequired,
+};
+
+export default CharacterCard;

--- a/pages/characters.js
+++ b/pages/characters.js
@@ -1,0 +1,36 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useEffect, useState } from 'react';
+import { Button } from 'react-bootstrap';
+import Link from 'next/link';
+import { useAuth } from '../utils/context/authContext';
+import { getCharacters } from '../api/characterData';
+import CharacterCard from '../components/CharacterCard';
+
+export default function ViewCharacters() {
+  const [char, setChar] = useState([]);
+
+  const { user } = useAuth();
+
+  const getAllChars = () => {
+    getCharacters(user.uid).then(setChar);
+  };
+
+  useEffect(() => {
+    getAllChars();
+  }, []);
+
+  return (
+    <>
+      <div id="characters-page">
+        <Link href="/character/new" passHref>
+          <Button>New Character</Button>
+        </Link>
+      </div>
+      <div className="d-flex flex-wrap">
+        {char.map((chars) => (
+          <CharacterCard key={chars.firebaseKey} charObj={chars} onUpdate={getAllChars} />
+        ))}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
With this branch, users are now able to see their characters by selecting "Characters" in the NavBar. On the characters page they will see repeated cards with the image, name and role of the character displayed. Two buttons will also appear on each card - edit and delete. 

## Related Issue
This is related to issue ticket #23 and #24.

## Motivation and Context
N/A

## How Can This Be Tested?
This has been tested by running the site on localhost. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
